### PR TITLE
Create availability control component

### DIFF
--- a/src/Livewire/AvailabilityControl.php
+++ b/src/Livewire/AvailabilityControl.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Reach\StatamicResrv\Livewire;
+
+use Livewire\Attributes\Session;
+use Livewire\Component;
+use Reach\StatamicResrv\Livewire\Forms\AvailabilityData;
+
+class AvailabilityControl extends Component
+{
+    #[Session('resrv-search')]
+    public AvailabilityData $data;
+
+    public function save(): void
+    {
+        $this->data->validate();
+
+        $this->dispatch('availability-search-updated', $this->data);
+    }
+
+    public function render()
+    {
+        return <<<'HTML'
+        <div></div>
+        HTML;
+    }
+}

--- a/src/Providers/ResrvLivewireProvider.php
+++ b/src/Providers/ResrvLivewireProvider.php
@@ -33,6 +33,7 @@ class ResrvLivewireProvider extends AddonServiceProvider
     {
         Livewire::component('availability-search', \Reach\StatamicResrv\Livewire\AvailabilitySearch::class);
         Livewire::component('availability-results', \Reach\StatamicResrv\Livewire\AvailabilityResults::class);
+        Livewire::component('availability-control', \Reach\StatamicResrv\Livewire\AvailabilityControl::class);
         Livewire::component('checkout', \Reach\StatamicResrv\Livewire\Checkout::class);
         Livewire::component('checkout-form', \Reach\StatamicResrv\Livewire\CheckoutForm::class);
         Livewire::component('checkout-payment', \Reach\StatamicResrv\Livewire\CheckoutPayment::class);

--- a/tests/Livewire/AvailabilityControlTest.php
+++ b/tests/Livewire/AvailabilityControlTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Reach\StatamicResrv\Tests\Livewire;
+
+use Livewire\Livewire;
+use Reach\StatamicResrv\Livewire\AvailabilityControl;
+use Reach\StatamicResrv\Livewire\AvailabilitySearch;
+use Reach\StatamicResrv\Tests\TestCase;
+
+class AvailabilityControlTest extends TestCase
+{
+    public $date;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->date = now()->setTime(12, 0, 0);
+        $this->travelTo(today()->setHour(12));
+    }
+
+    public function test_renders_successfully()
+    {
+        Livewire::test(AvailabilityControl::class)
+            ->assertStatus(200);
+    }
+
+    public function test_can_load_data_from_session()
+    {
+        Livewire::test(AvailabilitySearch::class)
+            ->set('data.dates',
+                [
+                    'date_start' => $this->date,
+                    'date_end' => $this->date->copy()->add(1, 'day'),
+                ]
+            )
+            ->set('data.quantity', 2)
+            ->set('data.advanced', 'test')
+            ->set('data.customer', ['adults' => 2]);
+
+        Livewire::test(AvailabilityControl::class)
+            ->assertSet('data.dates.date_start', $this->date)
+            ->assertSet('data.dates.date_end', $this->date->copy()->add(1, 'day'))
+            ->assertSet('data.quantity', 2)
+            ->assertSet('data.advanced', 'test')
+            ->assertSet('data.customer', ['adults' => 2]);
+    }
+
+    public function test_can_save_valid_data()
+    {
+        Livewire::test(AvailabilityControl::class)
+            ->set('data.dates', [
+                'date_start' => $this->date,
+                'date_end' => $this->date->copy()->add(1, 'day'),
+            ])
+            ->set('data.quantity', 2)
+            ->set('data.advanced', 'test')
+            ->set('data.customer', ['adults' => 2])
+            ->call('save')
+            ->assertDispatched('availability-search-updated', [
+                'dates' => [
+                    'date_start' => $this->date->toISOString(),
+                    'date_end' => $this->date->copy()->add(1, 'day')->toISOString(),
+                ],
+                'quantity' => 2,
+                'advanced' => 'test',
+                'customer' => ['adults' => 2],
+            ]);
+    }
+
+    public function test_validates_dates_before_save()
+    {
+        Livewire::test(AvailabilityControl::class)
+            ->set('data.dates', [
+                'date_start' => $this->date->copy()->add(1, 'day'),
+                'date_end' => $this->date,
+            ])
+            ->call('save')
+            ->assertHasErrors(['data.dates.date_start', 'data.dates.date_end'])
+            ->assertNotDispatched('availability-search-updated');
+    }
+}


### PR DESCRIPTION
This simple component can be used with AlpineJS to control the availability seach values anywhere in the page. Useful in buttons, call to actions and more.