### PR TITLE
Fix partner refunds

### DIFF
--- a/resources/views/email/reservations/refunded.blade.php
+++ b/resources/views/email/reservations/refunded.blade.php
@@ -13,7 +13,7 @@
 {{ __("Reservation code") }} **{{ $reservation->id }}**<br>
 {{ __("Date") }}: **{{ $reservation->updated_at->format('d-m-Y H:i') }}**<br>
 {{ __("Booking reference") }}: **{{ $reservation->reference }}**<br>
-{{ __("Email") }}: **{{ $reservation->customer->email }}** 
+{{ __("Email") }}: **{{ $reservation->customer?->email }}**
 @endcomponent
 
 @component('mail::table')

--- a/src/Http/Controllers/ReservationCpController.php
+++ b/src/Http/Controllers/ReservationCpController.php
@@ -211,16 +211,27 @@ class ReservationCpController extends Controller
             return response()->json(['error' => 'Cannot refund a reservation in the '.$reservation->status.' state.'], 422);
         }
 
-        $manager = app(PaymentGatewayManager::class);
-        try {
-            $payment = $manager->forReservation($reservation);
-        } catch (\InvalidArgumentException $e) {
-            $payment = $manager->gateway();
-        }
-        try {
-            $payment->refund($reservation);
-        } catch (RefundFailedException $exception) {
-            return response()->json(['error' => $exception->getMessage()], 400);
+        // Partner (affiliate skip-payment) and zero-payment reservations never create a payment
+        // intent, so payment_id stays '' — there is no charge on the gateway to refund. Skip the
+        // gateway call entirely or Stripe rejects the empty payment_intent and blocks the refund.
+        // Anything else with an empty payment_id (e.g. a PENDING row whose cancelled intent may
+        // still carry an orphaned charge) keeps going through the gateway so the failure surfaces
+        // to the admin instead of silently marking captured money as refunded.
+        $gatewayHoldsNoCharge = ($reservation->payment_id === '' || $reservation->payment_id === null)
+            && ($currentStatus === ReservationStatus::PARTNER || $reservation->payment->isZero());
+
+        if (! $gatewayHoldsNoCharge) {
+            $manager = app(PaymentGatewayManager::class);
+            try {
+                $payment = $manager->forReservation($reservation);
+            } catch (\InvalidArgumentException $e) {
+                $payment = $manager->gateway();
+            }
+            try {
+                $payment->refund($reservation);
+            } catch (RefundFailedException $exception) {
+                return response()->json(['error' => $exception->getMessage()], 400);
+            }
         }
 
         try {

--- a/tests/Reservation/ReservationCpTest.php
+++ b/tests/Reservation/ReservationCpTest.php
@@ -7,7 +7,12 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
 use Inertia\Testing\AssertableInertia;
+use Mockery;
+use Reach\StatamicResrv\Exceptions\RefundFailedException;
+use Reach\StatamicResrv\Http\Payment\FakePaymentGateway;
+use Reach\StatamicResrv\Http\Payment\PaymentGatewayManager;
 use Reach\StatamicResrv\Mail\ReservationRefunded;
+use Reach\StatamicResrv\Models\Affiliate;
 use Reach\StatamicResrv\Models\ChildReservation;
 use Reach\StatamicResrv\Models\Customer;
 use Reach\StatamicResrv\Models\Reservation;
@@ -375,6 +380,129 @@ class ReservationCpTest extends TestCase
 
         $response->assertStatus(200)->assertSee($reservation->id);
         Mail::assertSent(ReservationRefunded::class);
+    }
+
+    public function test_can_refund_partner_reservation_that_skipped_payment()
+    {
+        Mail::fake();
+        $item = $this->makeStatamicItem();
+
+        $reservation = Reservation::factory([
+            'item_id' => $item->id(),
+            'status' => 'partner',
+            'payment_id' => '',
+        ])->withCustomer()->create();
+
+        $affiliate = Affiliate::factory()->create();
+        $reservation->affiliate()->attach($affiliate->id, ['fee' => $affiliate->fee]);
+
+        // No payment intent was ever created, so the gateway must not be touched at all.
+        $manager = Mockery::mock(PaymentGatewayManager::class);
+        $manager->shouldNotReceive('forReservation');
+        $manager->shouldNotReceive('gateway');
+        app()->instance(PaymentGatewayManager::class, $manager);
+
+        $response = $this->patch(cp_route('resrv.reservation.refund', ['id' => $reservation->id]));
+
+        $response->assertStatus(200)->assertSee($reservation->id);
+        $this->assertDatabaseHas('resrv_reservations', [
+            'id' => $reservation->id,
+            'status' => 'refunded',
+        ]);
+        Mail::assertSent(ReservationRefunded::class);
+    }
+
+    public function test_refunding_partner_reservation_with_payment_still_calls_gateway()
+    {
+        Mail::fake();
+        $item = $this->makeStatamicItem();
+
+        $reservation = Reservation::factory([
+            'item_id' => $item->id(),
+            'status' => 'partner',
+            'payment_id' => 'pi_test123',
+        ])->withCustomer()->create();
+
+        $affiliate = Affiliate::factory()->create();
+        $reservation->affiliate()->attach($affiliate->id, ['fee' => $affiliate->fee]);
+
+        // A payment intent exists, so the charge must still be refunded through the gateway.
+        $manager = Mockery::mock(PaymentGatewayManager::class);
+        $manager->shouldReceive('forReservation')
+            ->once()
+            ->with(Mockery::on(fn ($r) => $r->id === $reservation->id))
+            ->andReturn(new FakePaymentGateway);
+        app()->instance(PaymentGatewayManager::class, $manager);
+
+        $response = $this->patch(cp_route('resrv.reservation.refund', ['id' => $reservation->id]));
+
+        $response->assertStatus(200)->assertSee($reservation->id);
+        $this->assertDatabaseHas('resrv_reservations', [
+            'id' => $reservation->id,
+            'status' => 'refunded',
+        ]);
+        Mail::assertSent(ReservationRefunded::class);
+    }
+
+    public function test_can_refund_zero_payment_reservation_without_touching_gateway()
+    {
+        Mail::fake();
+        $item = $this->makeStatamicItem();
+
+        $reservation = Reservation::factory([
+            'item_id' => $item->id(),
+            'status' => 'confirmed',
+            'payment' => 0,
+            'payment_id' => '',
+        ])->withCustomer()->create();
+
+        // Zero-payment checkouts never create a payment intent, so the gateway must not be touched.
+        $manager = Mockery::mock(PaymentGatewayManager::class);
+        $manager->shouldNotReceive('forReservation');
+        $manager->shouldNotReceive('gateway');
+        app()->instance(PaymentGatewayManager::class, $manager);
+
+        $response = $this->patch(cp_route('resrv.reservation.refund', ['id' => $reservation->id]));
+
+        $response->assertStatus(200)->assertSee($reservation->id);
+        $this->assertDatabaseHas('resrv_reservations', [
+            'id' => $reservation->id,
+            'status' => 'refunded',
+        ]);
+        Mail::assertSent(ReservationRefunded::class);
+    }
+
+    public function test_refunding_pending_reservation_with_cleared_payment_id_still_calls_gateway()
+    {
+        Mail::fake();
+        $item = $this->makeStatamicItem();
+
+        // A PENDING reservation whose intent was cancelled (payment_id cleared) may still carry
+        // an orphaned charge on the gateway, so the refund must go through the gateway and
+        // surface its failure instead of silently flipping the status to refunded.
+        $reservation = Reservation::factory([
+            'item_id' => $item->id(),
+            'status' => 'pending',
+            'payment_id' => '',
+        ])->withCustomer()->create();
+
+        $gateway = Mockery::mock(FakePaymentGateway::class)->makePartial();
+        $gateway->shouldReceive('refund')
+            ->once()
+            ->andThrow(new RefundFailedException('No such payment intent.'));
+
+        $manager = Mockery::mock(PaymentGatewayManager::class);
+        $manager->shouldReceive('forReservation')->once()->andReturn($gateway);
+        app()->instance(PaymentGatewayManager::class, $manager);
+
+        $response = $this->patch(cp_route('resrv.reservation.refund', ['id' => $reservation->id]));
+
+        $response->assertStatus(400);
+        $this->assertDatabaseHas('resrv_reservations', [
+            'id' => $reservation->id,
+            'status' => 'pending',
+        ]);
+        Mail::assertNothingSent();
     }
 
     public function test_refund_on_already_refunded_reservation_short_circuits_before_gateway()


### PR DESCRIPTION
## Problem

Partner (affiliate skip-payment) and zero-payment reservations never create a payment intent, so `payment_id` stays empty. `ReservationCpController::refund()` unconditionally calls the payment gateway, and Stripe rejects `refunds->create()` with an empty `payment_intent` — so these reservations could not be refunded from the CP at all, even though the state machine explicitly allows `PARTNER → REFUNDED`.

## What changed vs. the original PR

The original branch predated the `ReservationStatus` state-machine refactor (4071fdd), so it has been rebuilt on current `main`:

- **Dropped** the manual refundable-status list — `canTransitionTo()` already handles this (409 for already-refunded, 422 for non-transitionable states). Note the original list also conflicted with main: it allowed `COMPLETED` (now a reserved status with no transitions) and blocked `PENDING` (now a deliberate escape hatch, covered by an existing test).
- **Kept** the core fix, but narrowed it: the gateway is skipped only when the reservation provably never carried a charge (`PARTNER` status or zero payment) **and** `payment_id` is empty. A blanket empty-`payment_id` skip would have silently marked PENDING rows with a potential orphaned charge (intent cleared by `cancelActiveIntent`, stale charge succeeded) as refunded while money sits captured at Stripe — those still go through the gateway so the failure surfaces to the admin.
- **Hardened** `refunded.blade.php` with a null-safe `customer?->email`, so a configured `admins` recipient can't crash the queued refund email job for a reservation without a customer record.

## Tests

- `test_can_refund_partner_reservation_that_skipped_payment` — gateway never resolved, status flips, refund mail sent (fails without the fix)
- `test_refunding_partner_reservation_with_payment_still_calls_gateway` — a real charge still goes through the gateway
- `test_can_refund_zero_payment_reservation_without_touching_gateway`
- `test_refunding_pending_reservation_with_cleared_payment_id_still_calls_gateway` — orphaned-charge protection: gateway failure surfaces as 400, status stays pending

274 tests green across Payment / Affiliate / Reservation / Mail / Jobs / Listeners suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)