### PR TITLE
fix: minimum/maximum policies survive overrides and always run last

### DIFF
--- a/src/Models/DynamicPricing.php
+++ b/src/Models/DynamicPricing.php
@@ -169,7 +169,11 @@ class DynamicPricing extends Model
 
     public function apply($price)
     {
-        foreach ($this->toApply as $policy) {
+        [$clamps, $rest] = collect($this->toApply)->partition(
+            fn ($p) => in_array($p->amount_operation, ['minimum', 'maximum'], true)
+        );
+
+        foreach ($rest->merge($clamps) as $policy) {
             $method = $policy->amount_type;
             $price = $this->$method($price, $policy);
         }
@@ -468,11 +472,11 @@ class DynamicPricing extends Model
     protected function hasOverridingPolicy($pricings): bool|Collection
     {
         if ($pricing = $pricings->firstWhere('overrides_all', true)) {
-            if ($coupons = $pricings->whereNotNull('coupon')) {
-                return collect([$pricing])->merge($coupons);
-            }
+            $passthrough = $pricings->filter(fn ($p) => $p->coupon !== null
+                || in_array($p->amount_operation, ['minimum', 'maximum'], true)
+            );
 
-            return collect([$pricing]);
+            return collect([$pricing])->merge($passthrough)->unique('id');
         }
 
         return false;

--- a/tests/DynamicPricing/DynamicPricingApplyTest.php
+++ b/tests/DynamicPricing/DynamicPricingApplyTest.php
@@ -201,6 +201,102 @@ class DynamicPricingApplyTest extends TestCase
         $this->assertIndexPrice('150.00', '200.00');
     }
 
+    public function test_minimum_applies_after_overriding_policy()
+    {
+        $this->createAvailabilityForEntry($this->entry, 50, 2);
+
+        // Base total: 50 * 4 = 200. Override drops it 50%, floor lifts it back to 150.
+        $this->createDynamicPricing('overridesAll', [
+            'title' => 'Override 50% off',
+            'amount' => '50',
+        ], false);
+
+        $this->createDynamicPricing('fixedMinimum', [
+            'title' => 'Minimum 150',
+            'amount' => '150',
+        ], false);
+
+        // 200 → 100 after override → floored to 150.
+        $this->assertPrice('150.00', '200.00');
+        $this->assertIndexPrice('150.00', '200.00');
+    }
+
+    public function test_maximum_applies_after_overriding_policy()
+    {
+        $this->createAvailabilityForEntry($this->entry, 50, 2);
+
+        // Base total: 50 * 4 = 200. Override increases 50%, ceiling caps at 250.
+        $this->createDynamicPricing('overridesAll', [
+            'title' => 'Override 50% increase',
+            'amount_operation' => 'increase',
+            'amount' => '50',
+        ], false);
+
+        $this->createDynamicPricing('fixedMaximum', [
+            'title' => 'Maximum 250',
+            'amount' => '250',
+        ], false);
+
+        // 200 → 300 after override → capped at 250.
+        $this->assertPrice('250.00', '200.00');
+        $this->assertIndexPrice('250.00', '200.00');
+    }
+
+    public function test_minimum_runs_last_regardless_of_order()
+    {
+        $this->createAvailabilityForEntry($this->entry, 50, 2);
+
+        // Base total: 50 * 4 = 200.
+        $decrease = $this->createDynamicPricing('percentDecrease', [
+            'title' => 'Take 50% off',
+            'amount' => '50',
+        ], false);
+
+        $minimum = $this->createDynamicPricing('fixedMinimum', [
+            'title' => 'Minimum 150',
+            'amount' => '150',
+        ], false);
+
+        // Order would otherwise place the minimum before the decrease.
+        $minimum->update(['order' => 1]);
+        $decrease->update(['order' => 2]);
+
+        // Without the fix: minimum runs first (no-op), decrease drops to 100.
+        // With the fix: decrease runs first (200 → 100), minimum floors to 150.
+        $this->assertPrice('150.00', '200.00');
+        $this->assertIndexPrice('150.00', '200.00');
+    }
+
+    public function test_minimum_with_coupon_and_override()
+    {
+        $this->createAvailabilityForEntry($this->entry, 50, 2);
+
+        // Coupon-bound 10% decrease.
+        $this->createDynamicPricing('withCoupon', [
+            'title' => 'Coupon X 10% off',
+            'coupon' => 'X',
+            'amount' => '10',
+        ], false);
+
+        // Overrides-all 50% decrease.
+        $this->createDynamicPricing('overridesAll', [
+            'title' => 'Override 50% off',
+            'amount' => '50',
+        ], false);
+
+        // Floor at 150.
+        $this->createDynamicPricing('fixedMinimum', [
+            'title' => 'Minimum 150',
+            'amount' => '150',
+        ], false);
+
+        session(['resrv_coupon' => 'X']);
+
+        // Override + coupon + floor all coexist; floor wins (final 150 from base 200).
+        $this->assertPrice('150.00', '200.00');
+        $this->assertIndexPrice('150.00', '200.00');
+    }
+
     public function test_dynamic_pricing_date_conditions()
     {
         $this->createAvailabilityForEntry($this->entry, 25.23, 2);


### PR DESCRIPTION
## Summary

Two bugs in `src/Models/DynamicPricing.php` prevented `minimum` / `maximum` fixed-amount rules from acting as a true price floor/ceiling. They are intended to clamp the *final* reservation total — `minimum` lifts the price up to the floor, `maximum` caps it down to the ceiling — so they only make sense applied last, after every other policy.

### Bug 1 — `overrides_all` drops the floor/ceiling

`hasOverridingPolicy()` returned only the override (plus coupons) when any matched rule had `overrides_all = true`. Any minimum/maximum rule that also matched was silently dropped, so the clamp never ran.

Repro: a yacht with a `MINIMUM_PRICE` rule (fixed/minimum/2000) AND a `SPECIAL_OFFER` (percent/decrease/20%, `overrides_all = true`) for the same dates. Total before discounts: 1000.
- Expected: 2000 (floored)
- Actual: 800 (20% off, floor never ran)

### Bug 2 — ordering doesn't guarantee min/max runs last

`apply()` iterated `toApply` in whatever order `checkAllParameters()` returned (`sortBy('order')` ASC). If a project happened to assign a lower `order` to the minimum than to the discount, the minimum ran first against the un-discounted price (no-op) and the discount then dragged the price back below the intended floor.

The existing `test_minimum_applied_after_decrease_in_ordering` only passes today because it manually sets `order = 1` on the decrease and `order = 2` on the minimum — it does not assert the contract holds independently of `order`.

## Fix

- `hasOverridingPolicy()`: let minimum/maximum rules pass through the override filter the same way coupons already do (override + coupon-bound + clamps, deduplicated by id).
- `apply()`: partition policies into clamps vs. the rest and always iterate `rest → clamps`. `partition()` preserves relative order within each group, so non-clamp ordering and clamp-vs-clamp ordering by `order` are unchanged.

No public API, schema, migration, or coupon/decrease/increase semantics changed.

## New tests

Added to `tests/DynamicPricing/DynamicPricingApplyTest.php`:

- `test_minimum_applies_after_overriding_policy` — base 200, `overrides_all` 50% decrease, fixed/minimum 150 → expected 150.
- `test_maximum_applies_after_overriding_policy` — base 200, `overrides_all` 50% increase, fixed/maximum 250 → expected 250.
- `test_minimum_runs_last_regardless_of_order` — base 200, percent/decrease 50% (`order = 2`), fixed/minimum 150 (`order = 1`) → expected 150.
- `test_minimum_with_coupon_and_override` — base 200, coupon-bound 10% decrease, `overrides_all` 50% decrease, fixed/minimum 150, session coupon set → expected 150.

## Test plan

- [x] `vendor/bin/phpunit --filter DynamicPricingApplyTest` — 21/21 passing
- [x] `vendor/bin/phpunit` — full suite, 508/508 passing (1700 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)