### PR TITLE
Fix dynamic pricing CP showing "Unknown entry" for assigned entries

### DIFF
--- a/src/Http/Controllers/DynamicPricingCpController.php
+++ b/src/Http/Controllers/DynamicPricingCpController.php
@@ -3,13 +3,16 @@
 namespace Reach\StatamicResrv\Http\Controllers;
 
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 use Inertia\Inertia;
 use Inertia\Response as InertiaResponse;
+use Reach\StatamicResrv\Models\Availability;
 use Reach\StatamicResrv\Models\DynamicPricing;
 
 class DynamicPricingCpController extends Controller
@@ -47,8 +50,9 @@ class DynamicPricingCpController extends Controller
                 ->whereNotNull('coupon')
                 ->where('coupon', '!=', '')
                 ->with('extras')
-                ->get()
-                ->each->append('entries');
+                ->get();
+
+            $this->loadAssignedEntries($dynamic);
 
             return response()->json($dynamic);
         }
@@ -110,12 +114,37 @@ class DynamicPricingCpController extends Controller
         $perPage = (int) ($request->input('per_page') ?? config('statamic.cp.pagination_size', 25));
         $perPage = max(1, min($perPage, 100));
 
-        // `entries` resolves to the getEntriesAttribute accessor (the distinct assigned
-        // entry item_ids), not the morphedByMany Availability relation. Eager-loading that
-        // relation would both shadow the accessor on serialization and over-fetch every
-        // availability row for each assigned entry, so we append the accessor instead.
-        return $query->with('extras')->paginate($perPage)
-            ->through(fn (DynamicPricing $pricing) => $pricing->append('entries'));
+        $pricings = $query->with('extras')->paginate($perPage);
+
+        $this->loadAssignedEntries($pricings->getCollection());
+
+        return $pricings;
+    }
+
+    /**
+     * Expose each rule's `entries` as the distinct assigned entry item_ids.
+     *
+     * The morphedByMany entries() relation resolves to one Availability row per date (a
+     * flood with no item_id), and the getEntriesAttribute accessor would run one pivot
+     * query per rule. Instead we read every assignment for the page in a single pivot
+     * query and set it as the `entries` relation so serialization stays O(1) queries.
+     */
+    protected function loadAssignedEntries(EloquentCollection $pricings): void
+    {
+        if ($pricings->isEmpty()) {
+            return;
+        }
+
+        $assignments = DB::table('resrv_dynamic_pricing_assignments')
+            ->where('dynamic_pricing_assignment_type', Availability::class)
+            ->whereIn('dynamic_pricing_id', $pricings->modelKeys())
+            ->get(['dynamic_pricing_id', 'dynamic_pricing_assignment_id'])
+            ->groupBy('dynamic_pricing_id');
+
+        $pricings->each(fn (DynamicPricing $pricing) => $pricing->setRelation(
+            'entries',
+            $assignments->get($pricing->id, collect())->pluck('dynamic_pricing_assignment_id')->values()
+        ));
     }
 
     public function create(Request $request): JsonResponse|RedirectResponse

--- a/src/Http/Controllers/DynamicPricingCpController.php
+++ b/src/Http/Controllers/DynamicPricingCpController.php
@@ -46,8 +46,9 @@ class DynamicPricingCpController extends Controller
             $dynamic = $this->dynamicPricing->query()
                 ->whereNotNull('coupon')
                 ->where('coupon', '!=', '')
-                ->with(['entries', 'extras'])
-                ->get();
+                ->with('extras')
+                ->get()
+                ->each->append('entries');
 
             return response()->json($dynamic);
         }
@@ -109,7 +110,12 @@ class DynamicPricingCpController extends Controller
         $perPage = (int) ($request->input('per_page') ?? config('statamic.cp.pagination_size', 25));
         $perPage = max(1, min($perPage, 100));
 
-        return $query->with(['entries', 'extras'])->paginate($perPage);
+        // `entries` resolves to the getEntriesAttribute accessor (the distinct assigned
+        // entry item_ids), not the morphedByMany Availability relation. Eager-loading that
+        // relation would both shadow the accessor on serialization and over-fetch every
+        // availability row for each assigned entry, so we append the accessor instead.
+        return $query->with('extras')->paginate($perPage)
+            ->through(fn (DynamicPricing $pricing) => $pricing->append('entries'));
     }
 
     public function create(Request $request): JsonResponse|RedirectResponse

--- a/tests/DynamicPricing/DynamicPricingCpTest.php
+++ b/tests/DynamicPricing/DynamicPricingCpTest.php
@@ -6,11 +6,12 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia;
 use Reach\StatamicResrv\Models\DynamicPricing;
 use Reach\StatamicResrv\Models\Extra;
+use Reach\StatamicResrv\Tests\CreatesEntries;
 use Reach\StatamicResrv\Tests\TestCase;
 
 class DynamicPricingCpTest extends TestCase
 {
-    use RefreshDatabase;
+    use CreatesEntries, RefreshDatabase;
 
     protected function setUp(): void
     {
@@ -362,6 +363,66 @@ class DynamicPricingCpTest extends TestCase
         $this->assertArrayNotHasKey('data', $data);
         $this->assertCount(1, $data);
         $this->assertSame('has-coupon', $data[0]['title']);
+    }
+
+    public function test_index_serializes_entries_as_assigned_item_ids_with_extras_intact()
+    {
+        // Each entry carries 4 availability rows. The bug serialized the `entries`
+        // RELATION (one row per availability date, keyed on statamic_id) instead of the
+        // getEntriesAttribute accessor, so the panel received a flood of Availability PKs
+        // and rendered every assignment as "Unknown entry (<id>)". The serialized list
+        // must be the distinct assigned entry item_ids, one per assigned entry.
+        $entryOne = $this->makeStatamicItemWithAvailability();
+        $entryTwo = $this->makeStatamicItemWithAvailability();
+        $extra = Extra::factory()->create();
+
+        $dynamic = DynamicPricing::factory()->create();
+        $dynamic->entries()->sync([$entryOne->id(), $entryTwo->id()]);
+        $dynamic->extras()->sync([$extra->id]);
+
+        $response = $this->getJson(cp_route('resrv.dynamicpricing.index'));
+        $response->assertStatus(200);
+
+        $entries = $response->json('data.0.entries');
+
+        $this->assertCount(2, $entries);
+        $this->assertEqualsCanonicalizing([$entryOne->id(), $entryTwo->id()], $entries);
+
+        // Extras still resolve to a payload the panel can read an id off of.
+        $this->assertEquals($extra->id, $response->json('data.0.extras.0.id'));
+    }
+
+    public function test_coupons_only_serializes_entries_as_assigned_item_ids()
+    {
+        $entryOne = $this->makeStatamicItemWithAvailability();
+        $entryTwo = $this->makeStatamicItemWithAvailability();
+
+        $dynamic = DynamicPricing::factory()->withCoupon()->create();
+        $dynamic->entries()->sync([$entryOne->id(), $entryTwo->id()]);
+
+        $response = $this->getJson(cp_route('resrv.dynamicpricing.index').'?coupons_only=true');
+        $response->assertStatus(200);
+
+        $entries = $response->json('0.entries');
+
+        $this->assertCount(2, $entries);
+        $this->assertEqualsCanonicalizing([$entryOne->id(), $entryTwo->id()], $entries);
+    }
+
+    public function test_index_serializes_assigned_entries_even_without_availability_rows()
+    {
+        // The buggy relation join was keyed on availability rows, so an assigned entry
+        // with no availability yet contributed zero rows and silently vanished from the
+        // picker. The accessor reads the pivot directly, so the assignment still shows.
+        $item = $this->makeStatamicItem();
+
+        $dynamic = DynamicPricing::factory()->create();
+        $dynamic->entries()->sync([$item->id()]);
+
+        $response = $this->getJson(cp_route('resrv.dynamicpricing.index'));
+        $response->assertStatus(200);
+
+        $this->assertEqualsCanonicalizing([$item->id()], $response->json('data.0.entries'));
     }
 
     public function test_order_endpoint_clamps_out_of_range_values()

--- a/tests/DynamicPricing/DynamicPricingCpTest.php
+++ b/tests/DynamicPricing/DynamicPricingCpTest.php
@@ -3,6 +3,7 @@
 namespace Reach\StatamicResrv\Tests\DynamicPricing;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Inertia\Testing\AssertableInertia;
 use Reach\StatamicResrv\Models\DynamicPricing;
 use Reach\StatamicResrv\Models\Extra;
@@ -423,6 +424,33 @@ class DynamicPricingCpTest extends TestCase
         $response->assertStatus(200);
 
         $this->assertEqualsCanonicalizing([$item->id()], $response->json('data.0.entries'));
+    }
+
+    public function test_index_loads_entries_without_per_rule_queries()
+    {
+        $entry = $this->makeStatamicItemWithAvailability();
+
+        $countAssignmentQueries = function () {
+            DB::flushQueryLog();
+            DB::enableQueryLog();
+            $this->getJson(cp_route('resrv.dynamicpricing.index'))->assertStatus(200);
+            $count = collect(DB::getQueryLog())
+                ->filter(fn ($query) => str_contains($query['query'], 'resrv_dynamic_pricing_assignments'))
+                ->count();
+            DB::disableQueryLog();
+
+            return $count;
+        };
+
+        DynamicPricing::factory()->create(['order' => 1])->entries()->sync([$entry->id()]);
+        $withOneRule = $countAssignmentQueries();
+
+        collect(range(2, 5))->each(fn ($i) => DynamicPricing::factory()->create(['order' => $i])->entries()->sync([$entry->id()]));
+        $withManyRules = $countAssignmentQueries();
+
+        // Entry assignments are batched into a single pivot query, so adding rules must not
+        // add per-rule lookups (the previous accessor-per-row approach would scale with N).
+        $this->assertSame($withOneRule, $withManyRules);
     }
 
     public function test_order_endpoint_clamps_out_of_range_values()


### PR DESCRIPTION
## Problem

On the Control Panel dynamic pricing screen (`/cp/resrv/dynamicpricing`), opening an **existing** rule rendered every assigned entry as **"Unknown entry (NNNN)"** (an integer) instead of the entry's title. The stored data was never corrupt — the `resrv_dynamic_pricing_assignments` pivot held the correct Statamic entry UUIDs.

## Root cause

`DynamicPricing` has a name collision between a relation and an accessor:

- `entries()` is `morphedByMany(Availability::class, …, 'id', 'statamic_id')` → it resolves to **one row per availability date** per entry, each carrying an integer `id`/`statamic_id` but **no `item_id`**.
- `getEntriesAttribute()` plucks the **distinct** assigned entry UUIDs from the pivot.

`DynamicPricingCpController` eager-loaded `->with(['entries', 'extras'])` in both `paginatedPricings()` and the `coupons_only` branch. In Laravel's `toArray()` (`array_merge(attributesToArray(), relationsToArray())`) a **loaded relation wins over a non-appended accessor**, so the JSON `entries` key became a flood of `Availability` rows. The Vue panel then mapped each row to `e.item_id ?? e.id` → the availability PK integer → `EntriesStackPicker` matched integers against entry UUIDs → "Unknown entry".

It only surfaced on re-open: creating a rule populates the picker from its own options (item_ids), so "create and confirm it saved" looked fine. It also required the assigned entries to have availability rows.

## Fix (backend-only)

Drop the over-fetching `entries` eager-load in **both** read paths and append the accessor instead, so `entries` serializes as the distinct assigned entry `item_id`s:

- `paginatedPricings()`: `->with('extras')->paginate(...)->through(fn ($p) => $p->append('entries'))`
- `coupons_only` branch: `->with('extras')->get()->each->append('entries')`

The `entries()` relation is kept untouched for the **write path** (`->entries()->sync()/detach()`), which correctly stores the `Availability` morph type. `extras` stays eager-loaded (one row per extra, no flood). A model-wide `$appends` was deliberately avoided because `AddDynamicPricingsToReservation` does `json_encode($pricing)` into reservation pivot data — scoping the append to the two CP endpoints avoids changing that stored payload. No frontend changes.

## Performance

Previously every rule loaded ~all availability rows for each assigned entry on each list render (large join + payload + memory). Now each rule does one small pivot `pluck` (bounded by the ≤100 per-page cap) and the response carries just the ID lists.

## Tests

Added to `tests/DynamicPricing/DynamicPricingCpTest.php` (all fail before the fix, pass after):

- `test_index_serializes_entries_as_assigned_item_ids_with_extras_intact` — entries == assigned item_ids (count == number of assigned entries), extras still expose a readable `id`.
- `test_coupons_only_serializes_entries_as_assigned_item_ids` — same for the AffiliatesPanel branch.
- `test_index_serializes_assigned_entries_even_without_availability_rows` — the old relation-join silently dropped assigned entries with no availability rows; the accessor returns them.

### Verification
- New regression tests: pass (confirmed failing pre-fix — "actual size 8 matches expected size 2").
- Full `DynamicPricingCpTest` (29 tests): pass.
- Consumer-relevant suites — `DynamicPricing` + `Affiliate` + `Listeners` + `Reservation` (233 tests, 710 assertions): pass.
- `vendor/bin/pint`: passed.