### PR TITLE
Restrict affiliate skip-payment to link attributions; no commission for unpublished affiliates

### DIFF
--- a/database/migrations/2026_07_13_000000_add_source_to_resrv_reservation_affiliate.php
+++ b/database/migrations/2026_07_13_000000_add_source_to_resrv_reservation_affiliate.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('resrv_reservation_affiliate', function (Blueprint $table) {
+            // Rows written before this column existed were attributed via the affiliate cookie
+            // or a coupon with no way to tell them apart; defaulting to 'cookie' preserves the
+            // behavior they had at the time (both sources could skip payment).
+            $table->string('source')->default('cookie')->after('fee');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('resrv_reservation_affiliate', function (Blueprint $table) {
+            $table->dropColumn('source');
+        });
+    }
+};

--- a/src/Enums/AffiliateAttributionSource.php
+++ b/src/Enums/AffiliateAttributionSource.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Reach\StatamicResrv\Enums;
+
+/**
+ * How an affiliate got attributed to a reservation. Only cookie attributions (the customer
+ * arrived through the affiliate's link) may unlock the skip-payment checkout path — a coupon
+ * code can circulate publicly, so coupon attributions earn commission but never skip payment.
+ */
+enum AffiliateAttributionSource: string
+{
+    case Cookie = 'cookie';
+
+    case Coupon = 'coupon';
+}

--- a/src/Listeners/AddAffiliateToReservation.php
+++ b/src/Listeners/AddAffiliateToReservation.php
@@ -2,6 +2,7 @@
 
 namespace Reach\StatamicResrv\Listeners;
 
+use Reach\StatamicResrv\Enums\AffiliateAttributionSource;
 use Reach\StatamicResrv\Events\ReservationCreated;
 
 class AddAffiliateToReservation
@@ -12,6 +13,7 @@ class AddAffiliateToReservation
             // Snapshot the name/code so the report keeps history even after the affiliate is deleted.
             $event->reservation->affiliate()->attach($event->data->affiliate, [
                 'fee' => $event->data->affiliate->fee,
+                'source' => AffiliateAttributionSource::Cookie->value,
                 'data' => json_encode([
                     'name' => $event->data->affiliate->name,
                     'code' => $event->data->affiliate->code,

--- a/src/Listeners/AssociateAffiliateFromCoupon.php
+++ b/src/Listeners/AssociateAffiliateFromCoupon.php
@@ -34,6 +34,13 @@ class AssociateAffiliateFromCoupon
             return;
         }
 
+        // Unpublished affiliates are disabled: their coupon still discounts the reservation,
+        // but must not earn a commission attribution. This sits after the remove branch so
+        // removing the coupon still cleans up an attribution created while published.
+        if (! $affiliate->published) {
+            return;
+        }
+
         // Check if this affiliate is already associated with the reservation. This also keeps a
         // cookie-sourced attribution from being downgraded to coupon-sourced when the customer
         // enters the same affiliate's coupon.

--- a/src/Listeners/AssociateAffiliateFromCoupon.php
+++ b/src/Listeners/AssociateAffiliateFromCoupon.php
@@ -2,6 +2,7 @@
 
 namespace Reach\StatamicResrv\Listeners;
 
+use Reach\StatamicResrv\Enums\AffiliateAttributionSource;
 use Reach\StatamicResrv\Events\CouponUpdated;
 use Reach\StatamicResrv\Models\DynamicPricing;
 
@@ -22,14 +23,20 @@ class AssociateAffiliateFromCoupon
             return;
         }
 
-        // If removing coupon, unassociate the affiliate
+        // If removing coupon, unassociate the affiliate — but only a coupon-sourced attribution.
+        // A cookie attribution (the customer arrived through the affiliate link) must survive
+        // the coupon being removed.
         if ($event->remove === true) {
-            $event->reservation->affiliate()->detach($affiliate->id);
+            $event->reservation->affiliate()
+                ->wherePivot('source', AffiliateAttributionSource::Coupon->value)
+                ->detach($affiliate->id);
 
             return;
         }
 
-        // Check if this affiliate is already associated with the reservation
+        // Check if this affiliate is already associated with the reservation. This also keeps a
+        // cookie-sourced attribution from being downgraded to coupon-sourced when the customer
+        // enters the same affiliate's coupon.
         if ($event->reservation->affiliate()->where('affiliate_id', $affiliate->id)->exists()) {
             return;
         }
@@ -38,6 +45,7 @@ class AssociateAffiliateFromCoupon
         // keeps history even after the affiliate is deleted.
         $event->reservation->affiliate()->attach($affiliate->id, [
             'fee' => $affiliate->fee,
+            'source' => AffiliateAttributionSource::Coupon->value,
             'data' => json_encode([
                 'name' => $affiliate->name,
                 'code' => $affiliate->code,

--- a/src/Livewire/Traits/HandlesAffiliates.php
+++ b/src/Livewire/Traits/HandlesAffiliates.php
@@ -2,6 +2,7 @@
 
 namespace Reach\StatamicResrv\Livewire\Traits;
 
+use Reach\StatamicResrv\Enums\AffiliateAttributionSource;
 use Reach\StatamicResrv\Models\Affiliate;
 
 trait HandlesAffiliates
@@ -13,10 +14,12 @@ trait HandlesAffiliates
 
     public function affiliateCanSkipPayment(): bool
     {
-        if ($affiliate = $this->reservation->affiliate->first()) {
-            return $affiliate->allow_skipping_payment ?? false;
-        }
+        // Only a cookie attribution (the customer arrived through the affiliate link) can skip
+        // payment. Coupon-sourced attributions earn commission but pay like everyone else.
+        $affiliate = $this->reservation->affiliate()
+            ->wherePivot('source', AffiliateAttributionSource::Cookie->value)
+            ->first();
 
-        return false;
+        return $affiliate?->allow_skipping_payment ?? false;
     }
 }

--- a/src/Models/Affiliate.php
+++ b/src/Models/Affiliate.php
@@ -46,7 +46,7 @@ class Affiliate extends Model
 
     public function reservations(): BelongsToMany
     {
-        return $this->belongsToMany(Reservation::class, 'resrv_reservation_affiliate')->withPivot('fee', 'cancelled_at');
+        return $this->belongsToMany(Reservation::class, 'resrv_reservation_affiliate')->withPivot('fee', 'source', 'cancelled_at');
     }
 
     public function coupons(): BelongsToMany

--- a/src/Models/Reservation.php
+++ b/src/Models/Reservation.php
@@ -104,7 +104,7 @@ class Reservation extends Model
 
     public function affiliate(): BelongsToMany
     {
-        return $this->belongsToMany(Affiliate::class, 'resrv_reservation_affiliate')->withPivot('fee', 'cancelled_at');
+        return $this->belongsToMany(Affiliate::class, 'resrv_reservation_affiliate')->withPivot('fee', 'source', 'cancelled_at');
     }
 
     public function rate(): BelongsTo

--- a/tests/Affiliate/AffiliateCouponReservationTest.php
+++ b/tests/Affiliate/AffiliateCouponReservationTest.php
@@ -141,6 +141,62 @@ class AffiliateCouponReservationTest extends TestCase
         ]);
     }
 
+    public function test_unpublished_affiliate_does_not_get_attributed_from_coupon()
+    {
+        $item = $this->makeStatamicItem();
+
+        // Create a coupon owned by an unpublished (disabled) affiliate
+        $coupon = DynamicPricing::factory()->create(['coupon' => 'AFFILIATE10']);
+        $coupon->entries()->sync([$item->id()]);
+
+        $affiliate = Affiliate::factory()->create(['fee' => 10, 'published' => false]);
+        $affiliate->coupons()->sync([$coupon->id]);
+
+        $reservation = Reservation::factory()->create([
+            'item_id' => $item->id(),
+        ]);
+
+        CouponUpdated::dispatch($reservation, 'AFFILIATE10');
+
+        // The coupon itself keeps working, but no commission attribution is created
+        $this->assertDatabaseMissing('resrv_reservation_affiliate', [
+            'reservation_id' => $reservation->id,
+            'affiliate_id' => $affiliate->id,
+        ]);
+    }
+
+    public function test_removing_coupon_detaches_attribution_of_a_later_unpublished_affiliate()
+    {
+        $item = $this->makeStatamicItem();
+
+        $coupon = DynamicPricing::factory()->create(['coupon' => 'AFFILIATE10']);
+        $coupon->entries()->sync([$item->id()]);
+
+        $affiliate = Affiliate::factory()->create(['fee' => 10]);
+        $affiliate->coupons()->sync([$coupon->id]);
+
+        $reservation = Reservation::factory()->create([
+            'item_id' => $item->id(),
+        ]);
+
+        // Attribution created while the affiliate was published
+        CouponUpdated::dispatch($reservation, 'AFFILIATE10');
+        $this->assertDatabaseHas('resrv_reservation_affiliate', [
+            'reservation_id' => $reservation->id,
+            'affiliate_id' => $affiliate->id,
+        ]);
+
+        // The affiliate gets disabled, then the customer removes the coupon
+        $affiliate->update(['published' => false]);
+        CouponUpdated::dispatch($reservation, 'AFFILIATE10', true);
+
+        // The stale coupon attribution must still be cleaned up
+        $this->assertDatabaseMissing('resrv_reservation_affiliate', [
+            'reservation_id' => $reservation->id,
+            'affiliate_id' => $affiliate->id,
+        ]);
+    }
+
     public function test_removing_coupon_keeps_cookie_sourced_attribution()
     {
         $item = $this->makeStatamicItem();

--- a/tests/Affiliate/AffiliateCouponReservationTest.php
+++ b/tests/Affiliate/AffiliateCouponReservationTest.php
@@ -3,6 +3,7 @@
 namespace Reach\StatamicResrv\Tests\Affiliate;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Reach\StatamicResrv\Enums\AffiliateAttributionSource;
 use Reach\StatamicResrv\Events\CouponUpdated;
 use Reach\StatamicResrv\Models\Affiliate;
 use Reach\StatamicResrv\Models\DynamicPricing;
@@ -38,11 +39,12 @@ class AffiliateCouponReservationTest extends TestCase
         // Dispatch the CouponUpdated event
         CouponUpdated::dispatch($reservation, 'AFFILIATE10');
 
-        // Check that the affiliate is associated with the reservation
+        // Check that the affiliate is associated with the reservation, marked as coupon-sourced
         $this->assertDatabaseHas('resrv_reservation_affiliate', [
             'reservation_id' => $reservation->id,
             'affiliate_id' => $affiliate->id,
             'fee' => 10,
+            'source' => AffiliateAttributionSource::Coupon->value,
         ]);
     }
 
@@ -80,18 +82,27 @@ class AffiliateCouponReservationTest extends TestCase
         $affiliate = Affiliate::factory()->create(['fee' => 10]);
         $affiliate->coupons()->sync([$coupon->id]);
 
-        // Create a reservation and associate the affiliate
+        // Create a reservation and associate the affiliate as if the cookie path attributed it
         $reservation = Reservation::factory()->create([
             'item_id' => $item->id(),
         ]);
-        $reservation->affiliate()->attach($affiliate->id, ['fee' => 10]);
+        $reservation->affiliate()->attach($affiliate->id, [
+            'fee' => 10,
+            'source' => AffiliateAttributionSource::Cookie->value,
+        ]);
 
         // Dispatch the CouponUpdated event again
         CouponUpdated::dispatch($reservation, 'AFFILIATE10');
 
-        // Check that the affiliate is only associated once
+        // Check that the affiliate is only associated once and the cookie attribution
+        // was not downgraded to coupon-sourced
         $count = $reservation->affiliate()->where('affiliate_id', $affiliate->id)->count();
         $this->assertEquals(1, $count);
+        $this->assertDatabaseHas('resrv_reservation_affiliate', [
+            'reservation_id' => $reservation->id,
+            'affiliate_id' => $affiliate->id,
+            'source' => AffiliateAttributionSource::Cookie->value,
+        ]);
     }
 
     public function test_affiliate_is_unassociated_when_coupon_is_removed()
@@ -127,6 +138,76 @@ class AffiliateCouponReservationTest extends TestCase
         $this->assertDatabaseMissing('resrv_reservation_affiliate', [
             'reservation_id' => $reservation->id,
             'affiliate_id' => $affiliate->id,
+        ]);
+    }
+
+    public function test_removing_coupon_keeps_cookie_sourced_attribution()
+    {
+        $item = $this->makeStatamicItem();
+
+        // Create a coupon
+        $coupon = DynamicPricing::factory()->create(['coupon' => 'AFFILIATE10']);
+        $coupon->entries()->sync([$item->id()]);
+
+        // Create an affiliate and associate the coupon
+        $affiliate = Affiliate::factory()->create(['fee' => 10]);
+        $affiliate->coupons()->sync([$coupon->id]);
+
+        // Create a reservation attributed to the affiliate through their cookie (link visit)
+        $reservation = Reservation::factory()->create([
+            'item_id' => $item->id(),
+        ]);
+        $reservation->affiliate()->attach($affiliate->id, [
+            'fee' => 10,
+            'source' => AffiliateAttributionSource::Cookie->value,
+        ]);
+
+        // The customer enters and then removes the same affiliate's coupon
+        CouponUpdated::dispatch($reservation, 'AFFILIATE10');
+        CouponUpdated::dispatch($reservation, 'AFFILIATE10', true);
+
+        // The cookie attribution must survive the coupon removal
+        $this->assertDatabaseHas('resrv_reservation_affiliate', [
+            'reservation_id' => $reservation->id,
+            'affiliate_id' => $affiliate->id,
+            'source' => AffiliateAttributionSource::Cookie->value,
+        ]);
+    }
+
+    public function test_removing_coupon_detaches_only_the_coupon_sourced_affiliate()
+    {
+        $item = $this->makeStatamicItem();
+
+        // Create a coupon owned by affiliate B
+        $coupon = DynamicPricing::factory()->create(['coupon' => 'AFFILIATE10']);
+        $coupon->entries()->sync([$item->id()]);
+
+        $affiliateA = Affiliate::factory()->create(['fee' => 10, 'code' => 'AFF-A']);
+        $affiliateB = Affiliate::factory()->create(['fee' => 15, 'code' => 'AFF-B']);
+        $affiliateB->coupons()->sync([$coupon->id]);
+
+        // The reservation was attributed to affiliate A through their cookie
+        $reservation = Reservation::factory()->create([
+            'item_id' => $item->id(),
+        ]);
+        $reservation->affiliate()->attach($affiliateA->id, [
+            'fee' => 10,
+            'source' => AffiliateAttributionSource::Cookie->value,
+        ]);
+
+        // The customer enters and then removes affiliate B's coupon
+        CouponUpdated::dispatch($reservation, 'AFFILIATE10');
+        CouponUpdated::dispatch($reservation, 'AFFILIATE10', true);
+
+        // Affiliate B's coupon attribution is gone, affiliate A's cookie attribution stays
+        $this->assertDatabaseMissing('resrv_reservation_affiliate', [
+            'reservation_id' => $reservation->id,
+            'affiliate_id' => $affiliateB->id,
+        ]);
+        $this->assertDatabaseHas('resrv_reservation_affiliate', [
+            'reservation_id' => $reservation->id,
+            'affiliate_id' => $affiliateA->id,
+            'source' => AffiliateAttributionSource::Cookie->value,
         ]);
     }
 

--- a/tests/Livewire/AvailabilityResultsTest.php
+++ b/tests/Livewire/AvailabilityResultsTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Livewire\Livewire;
+use Reach\StatamicResrv\Enums\AffiliateAttributionSource;
 use Reach\StatamicResrv\Enums\CancellationPolicy;
 use Reach\StatamicResrv\Events\ReservationCreated;
 use Reach\StatamicResrv\Exceptions\AvailabilityException;
@@ -1374,6 +1375,7 @@ class AvailabilityResultsTest extends TestCase
                 'reservation_id' => 1,
                 'affiliate_id' => $affiliate->id,
                 'fee' => $affiliate->fee,
+                'source' => AffiliateAttributionSource::Cookie->value,
             ]
         );
     }

--- a/tests/Livewire/CheckoutTest.php
+++ b/tests/Livewire/CheckoutTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
 use Livewire\Livewire;
+use Reach\StatamicResrv\Enums\AffiliateAttributionSource;
 use Reach\StatamicResrv\Enums\ReservationStatus;
 use Reach\StatamicResrv\Events\CouponUpdated;
 use Reach\StatamicResrv\Events\ReservationConfirmed;
@@ -314,6 +315,70 @@ class CheckoutTest extends TestCase
 
         $this->assertEquals('expired', $reservation->fresh()->status);
         $this->assertFalse($confirmedDispatched, 'ReservationConfirmed must not fire when the PARTNER transition lost the race.');
+    }
+
+    public function test_affiliate_attributed_by_cookie_can_complete_checkout_without_payment()
+    {
+        Event::fake();
+
+        $affiliate = Affiliate::factory()->create(['allow_skipping_payment' => true]);
+        $this->reservation->affiliate()->attach($affiliate->id, [
+            'fee' => $affiliate->fee,
+            'source' => AffiliateAttributionSource::Cookie->value,
+        ]);
+
+        session(['resrv_reservation' => $this->reservation->id]);
+
+        $component = Livewire::test(Checkout::class)
+            ->call('handleFirstStep')
+            ->assertSet('step', 2)
+            ->assertSee(trans('statamic-resrv::frontend.completeWithoutPayment'));
+
+        $component->dispatch('checkout-form-submitted-without-payment')
+            ->assertRedirect(Entry::find(Config::get('resrv-config.checkout_completed_entry'))->absoluteUrl().'?payment_pending='.$this->reservation->id);
+
+        $this->assertEquals(ReservationStatus::PARTNER->value, $this->reservation->fresh()->status);
+    }
+
+    public function test_entering_an_affiliate_coupon_does_not_unlock_skip_payment()
+    {
+        $dynamic = DynamicPricing::factory()->withCoupon()->create();
+
+        DB::table('resrv_dynamic_pricing_assignments')->insert([
+            'dynamic_pricing_id' => $dynamic->id,
+            'dynamic_pricing_assignment_id' => $this->entries->first()->id,
+            'dynamic_pricing_assignment_type' => 'Reach\StatamicResrv\Models\Availability',
+        ]);
+
+        $affiliate = Affiliate::factory()->create(['allow_skipping_payment' => true]);
+        $affiliate->coupons()->sync([$dynamic->id]);
+
+        session(['resrv_reservation' => $this->reservation->id]);
+
+        $component = Livewire::test(Checkout::class);
+
+        $component->call('addCoupon', '20OFF')
+            ->assertSessionHas('resrv_coupon', '20OFF')
+            ->dispatch('coupon-applied', '20OFF');
+
+        // The coupon attributed the affiliate for commission, marked as coupon-sourced
+        $this->assertDatabaseHas('resrv_reservation_affiliate', [
+            'reservation_id' => $this->reservation->id,
+            'affiliate_id' => $affiliate->id,
+            'source' => AffiliateAttributionSource::Coupon->value,
+        ]);
+
+        // The skip-payment button must not render on the checkout form
+        $component->call('handleFirstStep')
+            ->assertSet('step', 2)
+            ->assertDontSee(trans('statamic-resrv::frontend.completeWithoutPayment'));
+
+        // A forged Livewire dispatch must be rejected server-side, not just hidden in the UI
+        $component->dispatch('checkout-form-submitted-without-payment')
+            ->assertNoRedirect()
+            ->assertHasErrors('reservation');
+
+        $this->assertEquals(ReservationStatus::PENDING->value, $this->reservation->fresh()->status);
     }
 
     public function test_it_shows_an_arror_if_the_reservation_is_expired()

--- a/tests/Livewire/CheckoutTest.php
+++ b/tests/Livewire/CheckoutTest.php
@@ -381,6 +381,38 @@ class CheckoutTest extends TestCase
         $this->assertEquals(ReservationStatus::PENDING->value, $this->reservation->fresh()->status);
     }
 
+    public function test_an_unpublished_affiliates_coupon_still_discounts_but_earns_no_attribution()
+    {
+        $dynamic = DynamicPricing::factory()->withCoupon()->create();
+
+        DB::table('resrv_dynamic_pricing_assignments')->insert([
+            'dynamic_pricing_id' => $dynamic->id,
+            'dynamic_pricing_assignment_id' => $this->entries->first()->id,
+            'dynamic_pricing_assignment_type' => 'Reach\StatamicResrv\Models\Availability',
+        ]);
+
+        $affiliate = Affiliate::factory()->create(['published' => false]);
+        $affiliate->coupons()->sync([$dynamic->id]);
+
+        session(['resrv_reservation' => $this->reservation->id]);
+
+        $component = Livewire::test(Checkout::class);
+
+        $component->call('addCoupon', '20OFF')
+            ->assertHasNoErrors('coupon')
+            ->assertSessionHas('resrv_coupon', '20OFF')
+            ->dispatch('coupon-applied', '20OFF');
+
+        // The discount applied even though the affiliate is disabled
+        $this->assertEquals('80.00', $this->reservation->fresh()->price->format());
+
+        // But the disabled affiliate earned no commission attribution
+        $this->assertDatabaseMissing('resrv_reservation_affiliate', [
+            'reservation_id' => $this->reservation->id,
+            'affiliate_id' => $affiliate->id,
+        ]);
+    }
+
     public function test_it_shows_an_arror_if_the_reservation_is_expired()
     {
         $reservation = Reservation::factory()->expired()->create([


### PR DESCRIPTION
## Problem

Entering an affiliate's coupon at checkout attached the affiliate to the reservation with the same standing as an affiliate-link visit. Since the skip-payment gate only checked *whether* an affiliate was attached, anyone holding a circulating coupon code from an `allow_skipping_payment` affiliate could complete checkout without paying.

Two adjacent issues in the same path:
- Removing a coupon detached the affiliate unconditionally — wiping a legitimate cookie (link) attribution if the customer entered and removed the same affiliate's coupon mid-checkout.
- The coupon path attached **unpublished** affiliates, contradicting the cookie path (which filters `published`) and the model's documented invariant.

## Fix

Attribution now records its source on the `resrv_reservation_affiliate` pivot (new `source` column, new `AffiliateAttributionSource` enum: `cookie` / `coupon`):

- **Skip-payment requires a cookie attribution.** `affiliateCanSkipPayment()` filters `wherePivot('source', 'cookie')`, which gates both the checkout-form button and the server-side guard on the `PARTNER` transition — a forged Livewire dispatch is rejected, not just hidden.
- **Coupon-sourced attributions still earn commission** but pay like everyone else.
- **Coupon removal only detaches coupon-sourced rows.** The existing already-associated guard keeps a cookie attribution from being downgraded when the same affiliate's coupon is entered, so add-then-remove leaves it intact.
- **Unpublished affiliates earn no attribution from coupons.** Their coupons still discount normally — only the commission row is withheld. The guard sits after the remove branch so removing a coupon still cleans up an attribution created while the affiliate was published.
- **Migration:** existing pivot rows default to `source = 'cookie'`, preserving the behavior they had when written.

## Tests

- Listener level (`AffiliateCouponReservationTest`): coupon attach stamps `coupon`; no downgrade of a cookie attribution; removal keeps cookie-sourced rows; with affiliate A (cookie) + affiliate B (coupon), removal detaches only B; unpublished affiliates get no attribution; removal still cleans up a later-unpublished affiliate's attribution.
- Checkout integration (`CheckoutTest`): real coupon flow → skip-payment button absent at step 2, forged `checkout-form-submitted-without-payment` dispatch errors and the reservation stays `pending`; cookie-attributed affiliate still sees the button and lands in `PARTNER`; unpublished affiliate's coupon still discounts (100 → 80) with no attribution row.
- Cookie path (`AvailabilityResultsTest`): asserts `source = 'cookie'`.

Suites green on SQLite and PostgreSQL (`tests/Affiliate`, `tests/Livewire`, `tests/Reservation`).