### PR TITLE
Make enable_affiliates disable the whole affiliate system

### DIFF
--- a/resources/blueprints/settings.yaml
+++ b/resources/blueprints/settings.yaml
@@ -99,7 +99,7 @@ tabs:
               default: true
               validate:
                 - required
-              instructions: 'Enable the [affiliate system](https://resrv.dev/affiliates).'
+              instructions: 'Enable the [affiliate system](https://resrv.dev/affiliates). When disabled, the whole system is off: affiliate cookies are not set, reservations get no affiliate attribution or commission (from links or coupons), affiliates cannot skip payment and no affiliate emails are sent. Existing attributions are kept for reporting and refunds.'
           -
             handle: enable_cutoff_rules
             field:

--- a/src/Http/Middleware/SetResrvAffiliateCookie.php
+++ b/src/Http/Middleware/SetResrvAffiliateCookie.php
@@ -18,7 +18,7 @@ class SetResrvAffiliateCookie
      */
     public function handle(Request $request, Closure $next)
     {
-        if ($request->missing('afid') || ! $request->isMethod('get')) {
+        if (! Affiliate::enabled() || $request->missing('afid') || ! $request->isMethod('get')) {
             return $next($request);
         }
 

--- a/src/Listeners/AddAffiliateToReservation.php
+++ b/src/Listeners/AddAffiliateToReservation.php
@@ -4,11 +4,16 @@ namespace Reach\StatamicResrv\Listeners;
 
 use Reach\StatamicResrv\Enums\AffiliateAttributionSource;
 use Reach\StatamicResrv\Events\ReservationCreated;
+use Reach\StatamicResrv\Models\Affiliate;
 
 class AddAffiliateToReservation
 {
     public function handle(ReservationCreated $event)
     {
+        if (! Affiliate::enabled()) {
+            return;
+        }
+
         if ($event->data->hasAffiliate()) {
             // Snapshot the name/code so the report keeps history even after the affiliate is deleted.
             $event->reservation->affiliate()->attach($event->data->affiliate, [

--- a/src/Listeners/AssociateAffiliateFromCoupon.php
+++ b/src/Listeners/AssociateAffiliateFromCoupon.php
@@ -11,10 +11,6 @@ class AssociateAffiliateFromCoupon
 {
     public function handle(CouponUpdated $event): void
     {
-        if (! Affiliate::enabled()) {
-            return;
-        }
-
         $coupon = DynamicPricing::searchForCoupon($event->coupon, $event->reservation->id);
 
         if (! $coupon) {
@@ -39,9 +35,16 @@ class AssociateAffiliateFromCoupon
             return;
         }
 
+        // The affiliate system being off blocks new attributions, like an unpublished affiliate
+        // does below. Both gates sit after the remove branch so removing the coupon still cleans
+        // up an attribution created while the feature was on and the affiliate published — the
+        // reservation must not keep an active commission for a coupon it no longer uses.
+        if (! Affiliate::enabled()) {
+            return;
+        }
+
         // Unpublished affiliates are disabled: their coupon still discounts the reservation,
-        // but must not earn a commission attribution. This sits after the remove branch so
-        // removing the coupon still cleans up an attribution created while published.
+        // but must not earn a commission attribution.
         if (! $affiliate->published) {
             return;
         }

--- a/src/Listeners/AssociateAffiliateFromCoupon.php
+++ b/src/Listeners/AssociateAffiliateFromCoupon.php
@@ -4,12 +4,17 @@ namespace Reach\StatamicResrv\Listeners;
 
 use Reach\StatamicResrv\Enums\AffiliateAttributionSource;
 use Reach\StatamicResrv\Events\CouponUpdated;
+use Reach\StatamicResrv\Models\Affiliate;
 use Reach\StatamicResrv\Models\DynamicPricing;
 
 class AssociateAffiliateFromCoupon
 {
     public function handle(CouponUpdated $event): void
     {
+        if (! Affiliate::enabled()) {
+            return;
+        }
+
         $coupon = DynamicPricing::searchForCoupon($event->coupon, $event->reservation->id);
 
         if (! $coupon) {

--- a/src/Livewire/Traits/HandlesAffiliates.php
+++ b/src/Livewire/Traits/HandlesAffiliates.php
@@ -9,11 +9,21 @@ trait HandlesAffiliates
 {
     public function getAffiliateIfCookieExists(): ?Affiliate
     {
+        // Gating the read (not just the cookie write) also neutralizes cookies set before
+        // the affiliate system was disabled.
+        if (! Affiliate::enabled()) {
+            return null;
+        }
+
         return request()->cookie('resrv_afid') ? Affiliate::published()->where('code', request()->cookie('resrv_afid'))->first() : null;
     }
 
     public function affiliateCanSkipPayment(): bool
     {
+        if (! Affiliate::enabled()) {
+            return false;
+        }
+
         // Only a cookie attribution (the customer arrived through the affiliate link) can skip
         // payment. Coupon-sourced attributions earn commission but pay like everyone else.
         $affiliate = $this->reservation->affiliate()

--- a/src/Models/Affiliate.php
+++ b/src/Models/Affiliate.php
@@ -38,6 +38,17 @@ class Affiliate extends Model
         return AffiliateFactory::new();
     }
 
+    /**
+     * The canonical read of the enable_affiliates setting. When false the whole affiliate
+     * system is off: no cookies, no attribution (cookie or coupon), no skip-payment, no
+     * affiliate emails, no CP nav or report section. Existing attributions are untouched
+     * so history, reports and refund flows keep working.
+     */
+    public static function enabled(): bool
+    {
+        return (bool) config('resrv-config.enable_affiliates', true);
+    }
+
     // Unpublished affiliates are disabled: they must not be cookied or attributed to reservations.
     public function scopePublished($query)
     {

--- a/src/Providers/ResrvProvider.php
+++ b/src/Providers/ResrvProvider.php
@@ -56,6 +56,7 @@ use Reach\StatamicResrv\Listeners\SendNewReservationEmails;
 use Reach\StatamicResrv\Listeners\SendRefundReservationEmails;
 use Reach\StatamicResrv\Listeners\SoftDeleteResrvEntryFromDatabase;
 use Reach\StatamicResrv\Listeners\UpdateCouponAppliedToReservation;
+use Reach\StatamicResrv\Models\Affiliate;
 use Reach\StatamicResrv\Models\Rate;
 use Reach\StatamicResrv\Scopes\ResrvSearch;
 use Reach\StatamicResrv\Support\ActivityLog;
@@ -317,7 +318,7 @@ class ResrvProvider extends AddonServiceProvider
                     ->icon('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" height="24" width="24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"><circle cx="12" cy="12" r="9.25"/><path d="M12 7v5l3.5 2"/></g></svg>');
             }
 
-            if (config('resrv-config.enable_affiliates', true)) {
+            if (Affiliate::enabled()) {
                 $nav->create(ucfirst(__('Affiliates')))
                     ->section('Resrv')
                     ->can('use resrv')

--- a/src/Resources/ReportResource.php
+++ b/src/Resources/ReportResource.php
@@ -3,6 +3,7 @@
 namespace Reach\StatamicResrv\Resources;
 
 use Illuminate\Http\Resources\Json\ResourceCollection;
+use Reach\StatamicResrv\Models\Affiliate;
 use Reach\StatamicResrv\Models\Report;
 
 class ReportResource extends ResourceCollection
@@ -24,7 +25,7 @@ class ReportResource extends ResourceCollection
         ];
 
         // Gate the affiliate section on the feature flag so the Vue panel hides when it's off.
-        if (config('resrv-config.enable_affiliates', true)) {
+        if (Affiliate::enabled()) {
             $data['affiliate_sales'] = $this->report->affiliateSales();
         }
 

--- a/src/Support/ReservationEmailRecipientResolver.php
+++ b/src/Support/ReservationEmailRecipientResolver.php
@@ -2,6 +2,7 @@
 
 namespace Reach\StatamicResrv\Support;
 
+use Reach\StatamicResrv\Models\Affiliate;
 use Reach\StatamicResrv\Models\Reservation;
 
 class ReservationEmailRecipientResolver
@@ -54,7 +55,7 @@ class ReservationEmailRecipientResolver
 
     protected function affiliateEmails(Reservation $reservation): array
     {
-        if (! config('resrv-config.enable_affiliates')) {
+        if (! Affiliate::enabled()) {
             return [];
         }
 

--- a/tests/Affiliate/AffiliateCouponReservationTest.php
+++ b/tests/Affiliate/AffiliateCouponReservationTest.php
@@ -192,6 +192,41 @@ class AffiliateCouponReservationTest extends TestCase
         ]);
     }
 
+    // Cleanup must survive the feature being turned off: an attribution created while the
+    // system was on must still be detached when its coupon is removed afterwards, or the
+    // reservation keeps an active commission for a coupon it no longer uses.
+    public function test_removing_coupon_detaches_attribution_after_affiliates_are_disabled()
+    {
+        $item = $this->makeStatamicItem();
+
+        $coupon = DynamicPricing::factory()->create(['coupon' => 'AFFILIATE10']);
+        $coupon->entries()->sync([$item->id()]);
+
+        $affiliate = Affiliate::factory()->create(['fee' => 10]);
+        $affiliate->coupons()->sync([$coupon->id]);
+
+        $reservation = Reservation::factory()->create([
+            'item_id' => $item->id(),
+        ]);
+
+        // Attribution created while the affiliate system was on
+        CouponUpdated::dispatch($reservation, 'AFFILIATE10');
+        $this->assertDatabaseHas('resrv_reservation_affiliate', [
+            'reservation_id' => $reservation->id,
+            'affiliate_id' => $affiliate->id,
+        ]);
+
+        // The system gets disabled, then the customer removes the coupon
+        Config::set('resrv-config.enable_affiliates', false);
+        CouponUpdated::dispatch($reservation, 'AFFILIATE10', true);
+
+        // The stale coupon attribution must still be cleaned up
+        $this->assertDatabaseMissing('resrv_reservation_affiliate', [
+            'reservation_id' => $reservation->id,
+            'affiliate_id' => $affiliate->id,
+        ]);
+    }
+
     public function test_removing_coupon_detaches_attribution_of_a_later_unpublished_affiliate()
     {
         $item = $this->makeStatamicItem();

--- a/tests/Affiliate/AffiliateCouponReservationTest.php
+++ b/tests/Affiliate/AffiliateCouponReservationTest.php
@@ -3,6 +3,7 @@
 namespace Reach\StatamicResrv\Tests\Affiliate;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
 use Reach\StatamicResrv\Enums\AffiliateAttributionSource;
 use Reach\StatamicResrv\Events\CouponUpdated;
 use Reach\StatamicResrv\Models\Affiliate;
@@ -45,6 +46,32 @@ class AffiliateCouponReservationTest extends TestCase
             'affiliate_id' => $affiliate->id,
             'fee' => 10,
             'source' => AffiliateAttributionSource::Coupon->value,
+        ]);
+    }
+
+    // With the affiliate system disabled the coupon still discounts, but no commission
+    // attribution is created — same contract as an unpublished affiliate.
+    public function test_affiliate_is_not_associated_when_affiliates_are_disabled()
+    {
+        Config::set('resrv-config.enable_affiliates', false);
+
+        $item = $this->makeStatamicItem();
+
+        $coupon = DynamicPricing::factory()->create(['coupon' => 'AFFILIATE10']);
+        $coupon->entries()->sync([$item->id()]);
+
+        $affiliate = Affiliate::factory()->create(['fee' => 10]);
+        $affiliate->coupons()->sync([$coupon->id]);
+
+        $reservation = Reservation::factory()->create([
+            'item_id' => $item->id(),
+        ]);
+
+        CouponUpdated::dispatch($reservation, 'AFFILIATE10');
+
+        $this->assertDatabaseMissing('resrv_reservation_affiliate', [
+            'reservation_id' => $reservation->id,
+            'affiliate_id' => $affiliate->id,
         ]);
     }
 

--- a/tests/Affiliate/AffiliateFrontTest.php
+++ b/tests/Affiliate/AffiliateFrontTest.php
@@ -3,7 +3,9 @@
 namespace Reach\StatamicResrv\Tests\Extra;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
+use Reach\StatamicResrv\Data\ReservationData;
 use Reach\StatamicResrv\Events\ReservationCreated as ReservationCreatedEvent;
 use Reach\StatamicResrv\Listeners\AddAffiliateToReservation;
 use Reach\StatamicResrv\Livewire\Traits\HandlesAffiliates;
@@ -85,6 +87,50 @@ class AffiliateFrontTest extends TestCase
         };
 
         $this->assertEquals($affiliate->id, $component->getAffiliateIfCookieExists()?->id);
+    }
+
+    // With the affiliate system disabled, the ?afid= parameter must be ignored entirely.
+    public function test_it_does_not_set_cookie_when_affiliates_are_disabled()
+    {
+        Config::set('resrv-config.enable_affiliates', false);
+
+        $affiliate = Affiliate::factory()->create();
+
+        $response = $this->get('/'.$this->item->slug.'?afid='.$affiliate->code);
+        $response->assertStatus(200)->assertCookieMissing('resrv_afid');
+    }
+
+    // A cookie set before the toggle was flipped off must be ignored at the read too,
+    // so no attribution can happen from pre-existing cookies.
+    public function test_get_affiliate_if_cookie_exists_returns_null_when_affiliates_are_disabled()
+    {
+        Config::set('resrv-config.enable_affiliates', false);
+
+        Affiliate::factory()->create(['code' => 'ENABLED', 'published' => true]);
+        request()->cookies->set('resrv_afid', 'ENABLED');
+
+        $component = new class
+        {
+            use HandlesAffiliates;
+        };
+
+        $this->assertNull($component->getAffiliateIfCookieExists());
+    }
+
+    public function test_listener_does_not_attribute_affiliate_when_affiliates_are_disabled()
+    {
+        Config::set('resrv-config.enable_affiliates', false);
+
+        $affiliate = Affiliate::factory()->create();
+        $reservation = Reservation::factory()->create();
+
+        (new AddAffiliateToReservation)->handle(new ReservationCreatedEvent($reservation, new ReservationData(
+            affiliate: $affiliate,
+        )));
+
+        $this->assertDatabaseMissing('resrv_reservation_affiliate', [
+            'reservation_id' => $reservation->id,
+        ]);
     }
 
     public function test_listener_listens_to_reservation_created_event()

--- a/tests/Livewire/AvailabilityResultsTest.php
+++ b/tests/Livewire/AvailabilityResultsTest.php
@@ -1380,6 +1380,38 @@ class AvailabilityResultsTest extends TestCase
         );
     }
 
+    // A cookie set while the affiliate system was on must not attribute once it is off.
+    public function test_creates_reservation_without_affiliate_when_affiliates_are_disabled()
+    {
+        Config::set('resrv-config.enable_affiliates', false);
+
+        $this->createCheckoutEntry();
+
+        $rateId = $this->getFirstAdvancedEntryRateId();
+
+        $affiliate = Affiliate::factory()->create();
+
+        $component = Livewire::withCookies(['resrv_afid' => $affiliate->code])
+            ->test(AvailabilityResults::class, ['entry' => $this->advancedEntries->first()->id()])
+            ->dispatch('availability-search-updated',
+                [
+                    'dates' => [
+                        'date_start' => $this->date->toISOString(),
+                        'date_end' => $this->date->copy()->add(2, 'day')->toISOString(),
+                    ],
+                    'quantity' => 1,
+                    'rate' => (string) $rateId,
+                ]
+            );
+
+        $component->call('checkout');
+
+        $this->assertDatabaseHas('resrv_reservations', ['id' => 1]);
+        $this->assertDatabaseMissing('resrv_reservation_affiliate', [
+            'reservation_id' => 1,
+        ]);
+    }
+
     public function test_cutoff_ignores_when_disabled_per_entry()
     {
         // Enable cutoff rules globally

--- a/tests/Livewire/CheckoutTest.php
+++ b/tests/Livewire/CheckoutTest.php
@@ -340,6 +340,33 @@ class CheckoutTest extends TestCase
         $this->assertEquals(ReservationStatus::PARTNER->value, $this->reservation->fresh()->status);
     }
 
+    public function test_affiliate_cannot_skip_payment_when_affiliates_are_disabled()
+    {
+        // The attribution predates the toggle flip: history is kept, but skip-payment is off.
+        Config::set('resrv-config.enable_affiliates', false);
+
+        $affiliate = Affiliate::factory()->create(['allow_skipping_payment' => true]);
+        $this->reservation->affiliate()->attach($affiliate->id, [
+            'fee' => $affiliate->fee,
+            'source' => AffiliateAttributionSource::Cookie->value,
+        ]);
+
+        session(['resrv_reservation' => $this->reservation->id]);
+
+        // The skip-payment button must not render on the checkout form
+        $component = Livewire::test(Checkout::class)
+            ->call('handleFirstStep')
+            ->assertSet('step', 2)
+            ->assertDontSee(trans('statamic-resrv::frontend.completeWithoutPayment'));
+
+        // A forged Livewire dispatch must be rejected server-side, not just hidden in the UI
+        $component->dispatch('checkout-form-submitted-without-payment')
+            ->assertNoRedirect()
+            ->assertHasErrors('reservation');
+
+        $this->assertEquals(ReservationStatus::PENDING->value, $this->reservation->fresh()->status);
+    }
+
     public function test_entering_an_affiliate_coupon_does_not_unlock_skip_payment()
     {
         $dynamic = DynamicPricing::factory()->withCoupon()->create();


### PR DESCRIPTION
## Summary

The `enable_affiliates` toggle previously only gated the CP nav, the reports section and affiliate email recipients — cookies, attribution (link and coupon) and skip-payment checkout kept working, silently dropping emails for bookings that still earned commission.

- Adds a canonical gate, `Affiliate::enabled()`, that now backs every affiliate surface: the `afid` cookie is never set, cookie and coupon attribution no-op (pre-existing cookies are neutralized at the read), and `affiliateCanSkipPayment()` returns `false` so the skip-payment button hides and the server-side confirm guard rejects forged dispatches.
- Existing attributions are untouched, so reports and refund flows keep working for reservations attributed while the feature was on.
- The gate in `AssociateAffiliateFromCoupon` sits *after* the coupon-removal branch (mirroring the unpublished-affiliate gate), so removing an affiliate coupon still cleans up its attribution while the toggle is off — only *new* attributions are blocked.

## Test plan

- New coverage in `tests/Affiliate/AffiliateFrontTest.php`, `tests/Affiliate/AffiliateCouponReservationTest.php`, `tests/Livewire/AvailabilityResultsTest.php` and `tests/Livewire/CheckoutTest.php` exercising the disabled-toggle paths (no cookie, no attribution, no skip-payment, coupon-removal cleanup still works).