### PR TITLE
Fix reservationFromUri tag: partner bookings and themed error pages

### DIFF
--- a/src/Tags/Resrv.php
+++ b/src/Tags/Resrv.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Validator;
 use Reach\StatamicResrv\Enums\ReservationStatus;
 use Reach\StatamicResrv\Models\Entry as ResrvEntry;
 use Reach\StatamicResrv\Models\Reservation;
+use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Tags\Tags;
 
 class Resrv extends Tags
@@ -30,20 +31,49 @@ class Resrv extends Tags
         ]);
 
         if ($validator->fails()) {
-            abort(400, 'Invalid reservation parameters.');
+            throw new NotFoundHttpException;
         }
 
         $reservation = Reservation::findForCustomerLookup(
             request()->get('ref'),
             request()->get('hash'),
-            [ReservationStatus::CONFIRMED->value],
+            $this->lookupStatuses(),
         );
 
         if (! $reservation) {
-            abort(404);
+            throw new NotFoundHttpException;
         }
 
         return $reservation;
+    }
+
+    /**
+     * Statuses a customer deep link may resolve to: live bookings (confirmed + partner) by
+     * default, or an explicit pipe-separated `statuses` parameter for pages that need more.
+     *
+     * @return string[]
+     */
+    protected function lookupStatuses(): array
+    {
+        $statuses = $this->params->get('statuses');
+
+        if (! $statuses) {
+            return ReservationStatus::live();
+        }
+
+        return collect(explode('|', $statuses))
+            ->map(fn (string $status) => trim($status))
+            ->map(function (string $status) {
+                $case = ReservationStatus::tryFrom($status);
+
+                if ($case === null) {
+                    throw new \Exception('Resrv Tag error: Invalid reservation status: '.$status);
+                }
+
+                return $case->value;
+            })
+            ->values()
+            ->all();
     }
 
     public function cutoff()

--- a/src/Tags/Resrv.php
+++ b/src/Tags/Resrv.php
@@ -63,7 +63,11 @@ class Resrv extends Tags
 
         return collect(explode('|', $statuses))
             ->map(fn (string $status) => trim($status))
-            ->map(function (string $status) {
+            ->map(function (string $status) use ($statuses) {
+                if ($status === '') {
+                    throw new \Exception('Resrv Tag error: Empty status segment in statuses parameter: '.$statuses);
+                }
+
                 $case = ReservationStatus::tryFrom($status);
 
                 if ($case === null) {

--- a/tests/Unit/ResrvTagTest.php
+++ b/tests/Unit/ResrvTagTest.php
@@ -212,6 +212,21 @@ class ResrvTagTest extends TestCase
         $this->tag->reservationFromUri();
     }
 
+    public function test_reservation_from_uri_throws_on_empty_status_segment_in_parameter()
+    {
+        request()->merge([
+            'ref' => 'TEST05',
+            'hash' => str_repeat('a', 64),
+        ]);
+
+        $this->tag->setParameters(['statuses' => 'confirmed|']);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Resrv Tag error: Empty status segment in statuses parameter: confirmed|');
+
+        $this->tag->reservationFromUri();
+    }
+
     public function test_reservation_from_uri_returns_404_for_wrong_hash()
     {
         $customer = Customer::factory()->create([

--- a/tests/Unit/ResrvTagTest.php
+++ b/tests/Unit/ResrvTagTest.php
@@ -11,8 +11,8 @@ use Reach\StatamicResrv\Models\Reservation;
 use Reach\StatamicResrv\Tags\Resrv;
 use Reach\StatamicResrv\Tests\CreatesEntries;
 use Reach\StatamicResrv\Tests\TestCase;
+use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Antlers;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ResrvTagTest extends TestCase
 {
@@ -36,6 +36,7 @@ class ResrvTagTest extends TestCase
         $this->tag = (new Resrv)
             ->setParser(Antlers::parser())
             ->setContext([]);
+        $this->tag->setParameters([]);
     }
 
     public function test_search_json_html_escapes_session_values()
@@ -114,6 +115,129 @@ class ResrvTagTest extends TestCase
 
         $reservation = $this->tag->reservationFromUri();
         $this->assertEquals($longRef, $reservation->reference);
+    }
+
+    public function test_reservation_from_uri_resolves_partner_reservation_by_default()
+    {
+        $customer = Customer::factory()->create([
+            'email' => 'partner@example.com',
+        ]);
+
+        $reservation = Reservation::factory()->create([
+            'item_id' => $this->entry->id(),
+            'status' => ReservationStatus::PARTNER,
+            'reference' => 'PARTNER01',
+            'customer_id' => $customer->id,
+        ]);
+
+        request()->merge([
+            'ref' => 'PARTNER01',
+            'hash' => $reservation->customerLookupHash(),
+        ]);
+
+        $reservation = $this->tag->reservationFromUri();
+        $this->assertEquals('PARTNER01', $reservation->reference);
+        $this->assertEquals(ReservationStatus::PARTNER->value, $reservation->status);
+    }
+
+    public function test_reservation_from_uri_statuses_parameter_overrides_default()
+    {
+        $customer = Customer::factory()->create([
+            'email' => 'cancelled@example.com',
+        ]);
+
+        $reservation = Reservation::factory()->create([
+            'item_id' => $this->entry->id(),
+            'status' => ReservationStatus::CANCELLED,
+            'reference' => 'CANCEL01',
+            'customer_id' => $customer->id,
+        ]);
+
+        request()->merge([
+            'ref' => 'CANCEL01',
+            'hash' => $reservation->customerLookupHash(),
+        ]);
+
+        // Cancelled is not in the default lookup statuses.
+        try {
+            $this->tag->reservationFromUri();
+            $this->fail('Expected NotFoundHttpException for a cancelled reservation without a statuses override.');
+        } catch (NotFoundHttpException $e) {
+            // expected
+        }
+
+        // Explicitly requesting cancelled resolves it.
+        $this->tag->setParameters(['statuses' => 'confirmed|cancelled']);
+
+        $found = $this->tag->reservationFromUri();
+        $this->assertEquals('CANCEL01', $found->reference);
+    }
+
+    public function test_reservation_from_uri_statuses_parameter_excludes_default_statuses()
+    {
+        $customer = Customer::factory()->create([
+            'email' => 'partneronly@example.com',
+        ]);
+
+        $reservation = Reservation::factory()->create([
+            'item_id' => $this->entry->id(),
+            'status' => ReservationStatus::CONFIRMED,
+            'reference' => 'CONF01',
+            'customer_id' => $customer->id,
+        ]);
+
+        request()->merge([
+            'ref' => 'CONF01',
+            'hash' => $reservation->customerLookupHash(),
+        ]);
+
+        $this->tag->setParameters(['statuses' => 'partner']);
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->tag->reservationFromUri();
+    }
+
+    public function test_reservation_from_uri_throws_on_invalid_status_in_parameter()
+    {
+        request()->merge([
+            'ref' => 'TEST03',
+            'hash' => str_repeat('a', 64),
+        ]);
+
+        $this->tag->setParameters(['statuses' => 'confirmed|not-a-status']);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Resrv Tag error: Invalid reservation status: not-a-status');
+
+        $this->tag->reservationFromUri();
+    }
+
+    public function test_reservation_from_uri_returns_404_for_wrong_hash()
+    {
+        $customer = Customer::factory()->create([
+            'email' => 'wronghash@example.com',
+        ]);
+
+        Reservation::factory()->create([
+            'item_id' => $this->entry->id(),
+            'status' => ReservationStatus::CONFIRMED,
+            'reference' => 'TEST04',
+            'customer_id' => $customer->id,
+        ]);
+
+        request()->merge([
+            'ref' => 'TEST04',
+            'hash' => str_repeat('b', 64),
+        ]);
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->tag->reservationFromUri();
+    }
+
+    public function test_reservation_from_uri_returns_404_for_missing_parameters()
+    {
+        $this->expectException(NotFoundHttpException::class);
+        $this->tag->reservationFromUri();
     }
 
     public function test_cutoff_throws_exception_when_no_entry_id()


### PR DESCRIPTION
## Summary
- `{{ resrv:reservationFromUri }}` now resolves **partner** reservations by default, not just confirmed ones. Affiliate skip-payment bookings end their lifecycle at status `partner` (the terminal-equivalent of confirmed — see `Checkout::handleReservationWithoutPayment()`), so customer-facing pages built on this tag (e.g. a passenger-details form linked from the confirmation email) always 404'd for partner bookings even with a valid hash. Defaults come from the existing `ReservationStatus::live()` helper.
- Added a `statuses` tag parameter to override the default, e.g. `{{ resrv:reservationFromUri statuses="confirmed|cancelled" }}`. Every value is validated against `ReservationStatus` and an invalid value throws `Resrv Tag error: Invalid reservation status: <value>`. Pending/expired/cancelled stay excluded unless explicitly requested.
- Replaced `abort(400)` / `abort(404)` with `Statamic\Exceptions\NotFoundHttpException`. Plain aborts bypass Statamic's `RendersHttpExceptions` trait, so a site's themed `errors/404.antlers.html` rendered without the layout. The invalid-parameters case also throws the 404 exception instead of a bare Symfony 400 page, which additionally avoids leaking whether the params were malformed vs. wrong.

## Tests
Six new tests in `tests/Unit/ResrvTagTest.php`:
- partner reservation with valid hash resolves via the default statuses
- `statuses` param resolves an explicitly-requested cancelled booking (and 404s it without the param)
- restrictive `statuses="partner"` param excludes a confirmed booking
- invalid status string in the param throws with a clear message
- wrong hash and missing params both 404 via Statamic's exception (assertions pin `Statamic\Exceptions\NotFoundHttpException`)

Full suite: 1568 tests, 4863 assertions, 0 failures (1 pre-existing skip). Pint clean.